### PR TITLE
Remove updates from request path, make concurrent safe

### DIFF
--- a/libvuln/opts.go
+++ b/libvuln/opts.go
@@ -65,15 +65,7 @@ type Opts struct {
 // defaultMacheter is a variable containing
 // all the matchers libvuln will use to match
 // index records to vulnerabilities.
-var defaultMatchers = []driver.Matcher{
-	&alpine.Matcher{},
-	&aws.Matcher{},
-	&debian.Matcher{},
-	&python.Matcher{},
-	&ubuntu.Matcher{},
-	rhel.NewMatcher(nil),
-	&photon.Matcher{},
-}
+var defaultMatchers []driver.Matcher
 
 // parse is an internal method for constructing
 // the necessary Updaters and Matchers for Libvuln
@@ -90,6 +82,17 @@ func (o *Opts) parse(ctx context.Context) error {
 	}
 	if o.MaxConnPool == 0 {
 		o.MaxConnPool = DefaultMaxConnPool
+	}
+
+	// initialize default matchers
+	defaultMatchers = []driver.Matcher{
+		&alpine.Matcher{},
+		&aws.Matcher{},
+		&debian.Matcher{},
+		&python.Matcher{},
+		&ubuntu.Matcher{},
+		rhel.NewMatcher(ctx, nil),
+		&photon.Matcher{},
 	}
 
 	// merge default matchers with any out-of-tree specified

--- a/pkg/omnimatcher/omnimatcher.go
+++ b/pkg/omnimatcher/omnimatcher.go
@@ -20,7 +20,7 @@ var defaultOmniMatcher = []driver.Matcher{
 	&aws.Matcher{},
 	&debian.Matcher{},
 	&python.Matcher{},
-	rhel.NewMatcher(nil),
+	rhel.NewMatcher(context.TODO(), nil),
 	&ubuntu.Matcher{},
 }
 

--- a/rhel/repo2cpe/repositorycpe.go
+++ b/rhel/repo2cpe/repositorycpe.go
@@ -7,7 +7,6 @@ import (
 // RepoCPEUpdater provides interface for providing a mapping
 // between repositories and CPEs
 type RepoCPEUpdater interface {
-	Update(context.Context) error
 	Get(context.Context, []string) ([]string, error)
 }
 
@@ -18,10 +17,6 @@ type RepoCPEMapping struct {
 
 // RepositoryToCPE translates repositories into CPEs
 func (mapping *RepoCPEMapping) RepositoryToCPE(ctx context.Context, repositories []string) ([]string, error) {
-	err := mapping.Update(ctx)
-	if err != nil {
-		return nil, err
-	}
 	cpes, err := mapping.Get(ctx, repositories)
 	return cpes, err
 }


### PR DESCRIPTION
This commit changes the LocalUpdaterJob in such a way that updating the
MappingFile will not occur during ClairCore matching process.

It also adapts the LocalUpdaterJob to be concurrent safe and allows the
RHEL matcher to be shared between goroutines.

@Allda can you please test this and merge into your existing PR to continue. 

Signed-off-by: ldelossa <ldelossa@redhat.com>