### PR TITLE
Use do once to ensure single updater job

### DIFF
--- a/rhel/repositoryscanner_test.go
+++ b/rhel/repositoryscanner_test.go
@@ -85,7 +85,7 @@ func TestRepositoryScanner(t *testing.T) {
 					CPE:  cpe.MustUnbind("cpe:/o:redhat:enterprise_linux:8::baseos"),
 				},
 			},
-			cfg:       &RepoScannerConfig{API: srv.URL},
+			cfg:       &RepoScannerConfig{API: srv.URL, Repo2CPEMappingURL: srv.URL + "/repository-2-cpe.json"},
 			layerPath: "testdata/layer-with-cpe.tar",
 		},
 		{


### PR DESCRIPTION
this commit adds a sync.once to the Updater constructor to ensure only a
single UpdaterJob is created on constructions.

Signed-off-by: ldelossa <ldelossa@redhat.com>